### PR TITLE
商品出品機能の実装（JavaScriptによる複数画像投稿）

### DIFF
--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -1,5 +1,27 @@
 $(function() {
 
+  function buildFileField(index) {
+    let html = `<div class="sell__product__image__box__data" data-index="${index}">
+    <label class="sell__product__image__box__data__upload" for="product_product_images_attributes_${index}_image"><input accept="image/png,image/jpeg" style="display:none" class="sell__product__image__box__data__upload--js-file" type="file" name="product[product_images_attributes][${index}][image]" id="product_product_images_attributes_${index}_image">
+    <span class="sell__product__image__box__data__upload--js-remove">削除</span>
+    </label></div>`;
+    return html;
+  }
+
+  let fileIndex = [1,2,3,4,5,6,7,8,9,10];
+
+  $('.sell__product__image__box').on('change', '.sell__product__image__box__data__upload--js-file', function(e) {
+    $('.sell__product__image__box').append(buildFileField(fileIndex[0]));
+    fileIndex.shift();
+    fileIndex.push(fileIndex[fileIndex.length - 1] + 1)
+  });
+
+  $('.sell__product__image__box').on('click', '.sell__product__image__box__data__upload--js-remove', function() {
+    $(this).parent().remove();
+    if ($('.sell__product__image__box__data__upload--js-file').length == 0) $('.sell__product__image__box').append(buildFileField(fileIndex[0]));
+  });
+
+
   $('.sell__product__price--input').change(function() {
     let commission = 10; 
     let value = $(this).val();
@@ -14,5 +36,5 @@ $(function() {
       $('.sell__product__fee__profit--js').text("¥" + value_profit);  
     }
   });
-  
+
 });

--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -8,39 +8,43 @@ $(function() {
   function buildFileField(index) {
     let html = `<div class="sell__product__image__box__data" data-index="${index}">
                 <label class="sell__product__image__box__data__upload" for="product_product_images_attributes_${index}_image"><input accept="image/png,image/jpeg" style="display:none" class="sell__product__image__box__data__upload--js-file" type="file" name="product[product_images_attributes][${index}][image]" id="product_product_images_attributes_${index}_image">
-                <span class="sell__product__image__box__data__upload--js-remove" data-index="${index}">削除</span>
+                <img height="18" src="/icon_camera.png" width="20">
+                <p class="sell__product__image__box__data__upload--js-select">選択</p>
+                <span class="sell__product__image__box__data__upload--js-remove" style="visibility:hidden" data-index="${index}">削除</span>
                 </label></div>`;
     return html;
   }
 
   let fileIndex = [1,2,3,4,5,6,7,8,9,10];
 
-  $('.sell__product__image__box').on('change', '.sell__product__image__box__data__upload--js-file', function(e) {
-    let targetIndex =  $(this).context.id.replace(/[^0-9]/g, '');
-    // ファイルのブラウザ上でのURLを取得する
-    let file = e.target.files[0];
-    let blobUrl = window.URL.createObjectURL(file);
+    $('.sell__product__image__box').on('change', '.sell__product__image__box__data__upload--js-file', function(e) {
+      let targetIndex =  $(this).context.id.replace(/[^0-9]/g, '');
+      let file = e.target.files[0];
+      let blobUrl = window.URL.createObjectURL(file);
+      let index =  $(".sell__product__image--preview").children().length
 
-    // 該当indexを持つimgがあれば取得して変数imgに入れる(画像変更の処理)
-    if (img = $(`img[data-index="${targetIndex}"]`)[0]) {
-      img.setAttribute('src', blobUrl);
-    } else {  // 新規画像追加の処理
-      $('.sell__product__image--preview').append(buildImg(targetIndex, blobUrl));
-      // fileIndexの先頭の数字を使ってinputを作る
-      $('.sell__product__image__box').append(buildFileField(fileIndex[0]));
-      fileIndex.shift();
-      // 末尾の数に1足した数を追加する
-      fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
-    }
-  });
+      if  (index <= 9) { 
+        // 該当indexを持つimgがあれば取得して変数imgに入れる(画像変更の処理)
+        if (img = $(`img[data-index="${targetIndex}"]`)[0]) {
+          img.setAttribute('src', blobUrl);
+        } else {  // 新規画像追加の処理
+          $('.sell__product__image__box__data__upload--js-remove').attr('style', 'visibility:visible');
+          $('.sell__product__image--preview').append(buildImg(targetIndex, blobUrl));
+          // fileIndexの先頭の数字を使ってinputを作る
+            $('.sell__product__image__box').append(buildFileField(fileIndex[0]));
+            fileIndex.shift();
+          // 末尾の数に1足した数を追加する
+          fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
+          console.log(index);
+        }
+      }
+    });
+
+
 
   $('.sell__product__image__box').on('click', '.sell__product__image__box__data__upload--js-remove', function() {
     let targetIndex =  $(this).context.getAttribute("data-index");
-    // 該当indexを振られているチェックボックスを取得する
-    const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-destroy`);
-    // もしチェックボックスが存在すればチェックを入れる
-    if (hiddenCheck) hiddenCheck.prop('checked', true);
-    $(this).parent().remove();
+    $(this).parent().parent().remove();
     $(`img[data-index="${targetIndex}"]`).remove();
     if ($('.sell__product__image__box__data__upload--js-file').length == 0) $('.sell__product__image__box').append(buildFileField(fileIndex[0]));
   });

--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -24,23 +24,17 @@ $(function() {
       let index =  $(".sell__product__image--preview").children().length
 
       if  (index <= 9) { 
-        // 該当indexを持つimgがあれば取得して変数imgに入れる(画像変更の処理)
         if (img = $(`img[data-index="${targetIndex}"]`)[0]) {
           img.setAttribute('src', blobUrl);
-        } else {  // 新規画像追加の処理
+        } else {
           $('.sell__product__image__box__data__upload--js-remove').attr('style', 'visibility:visible');
           $('.sell__product__image--preview').append(buildImg(targetIndex, blobUrl));
-          // fileIndexの先頭の数字を使ってinputを作る
             $('.sell__product__image__box').append(buildFileField(fileIndex[0]));
             fileIndex.shift();
-          // 末尾の数に1足した数を追加する
           fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
-          console.log(index);
         }
       }
     });
-
-
 
   $('.sell__product__image__box').on('click', '.sell__product__image__box__data__upload--js-remove', function() {
     let targetIndex =  $(this).context.getAttribute("data-index");

--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -1,23 +1,47 @@
 $(function() {
 
+  function buildImg(index, url) {
+    let html = `<img data-index="${index}" src="${url}" width="100px" height="100px">`;
+    return html;
+  }
+
   function buildFileField(index) {
     let html = `<div class="sell__product__image__box__data" data-index="${index}">
-    <label class="sell__product__image__box__data__upload" for="product_product_images_attributes_${index}_image"><input accept="image/png,image/jpeg" style="display:none" class="sell__product__image__box__data__upload--js-file" type="file" name="product[product_images_attributes][${index}][image]" id="product_product_images_attributes_${index}_image">
-    <span class="sell__product__image__box__data__upload--js-remove">削除</span>
-    </label></div>`;
+                <label class="sell__product__image__box__data__upload" for="product_product_images_attributes_${index}_image"><input accept="image/png,image/jpeg" style="display:none" class="sell__product__image__box__data__upload--js-file" type="file" name="product[product_images_attributes][${index}][image]" id="product_product_images_attributes_${index}_image">
+                <span class="sell__product__image__box__data__upload--js-remove" data-index="${index}">削除</span>
+                </label></div>`;
     return html;
   }
 
   let fileIndex = [1,2,3,4,5,6,7,8,9,10];
 
   $('.sell__product__image__box').on('change', '.sell__product__image__box__data__upload--js-file', function(e) {
-    $('.sell__product__image__box').append(buildFileField(fileIndex[0]));
-    fileIndex.shift();
-    fileIndex.push(fileIndex[fileIndex.length - 1] + 1)
+    let targetIndex =  $(this).context.id.replace(/[^0-9]/g, '');
+    // ファイルのブラウザ上でのURLを取得する
+    let file = e.target.files[0];
+    let blobUrl = window.URL.createObjectURL(file);
+
+    // 該当indexを持つimgがあれば取得して変数imgに入れる(画像変更の処理)
+    if (img = $(`img[data-index="${targetIndex}"]`)[0]) {
+      img.setAttribute('src', blobUrl);
+    } else {  // 新規画像追加の処理
+      $('.sell__product__image--preview').append(buildImg(targetIndex, blobUrl));
+      // fileIndexの先頭の数字を使ってinputを作る
+      $('.sell__product__image__box').append(buildFileField(fileIndex[0]));
+      fileIndex.shift();
+      // 末尾の数に1足した数を追加する
+      fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
+    }
   });
 
   $('.sell__product__image__box').on('click', '.sell__product__image__box__data__upload--js-remove', function() {
+    let targetIndex =  $(this).context.getAttribute("data-index");
+    // 該当indexを振られているチェックボックスを取得する
+    const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-destroy`);
+    // もしチェックボックスが存在すればチェックを入れる
+    if (hiddenCheck) hiddenCheck.prop('checked', true);
     $(this).parent().remove();
+    $(`img[data-index="${targetIndex}"]`).remove();
     if ($('.sell__product__image__box__data__upload--js-file').length == 0) $('.sell__product__image__box').append(buildFileField(fileIndex[0]));
   });
 

--- a/app/assets/stylesheets/products_new.scss
+++ b/app/assets/stylesheets/products_new.scss
@@ -70,6 +70,10 @@ $color-4: #ccc;
         font-size: 14px;
         line-height: 1.4em;
       }
+      &--preview {
+        width: 500px;
+        margin: 0 auto;
+      }
       &__box {
         width: 620px;
         &__data {

--- a/app/assets/stylesheets/products_new.scss
+++ b/app/assets/stylesheets/products_new.scss
@@ -53,10 +53,10 @@ $color-4: #ccc;
     }
   }
   &__product {
-    height: 2200px;
     width: 700px;
     background-color: $color-1;
     margin: 0 auto;
+    padding-bottom: 50px;
     &__image {
       @extend %box-style;
       &--label {
@@ -75,21 +75,35 @@ $color-4: #ccc;
         margin: 0 auto;
       }
       &__box {
-        width: 620px;
+        width: 500px;
+        height: 70px;
+        margin: 0 auto;
+        display: flex;
+        flex-wrap: wrap;
         &__data {
+          width: 100px;
           &__upload {
-            height: 150px;
-            width: 620px;
+            height: 20px;
+            width: 100px;
             background-color: $color-0;
             margin-top: 16px;
             font-size: 12px;
             display: flex;
             align-items: center;
-            justify-content: center;
+            justify-content: space-between;
             width: 100%;
             border-width: 1px;
             border-style: dashed;
             border-color: $color-4;
+            &--js-select {
+              width: 30px;
+              text-align: center;
+            }
+            &--js-remove {
+              width: 50px;
+              text-align: center;
+              border-left: 1px dashed $color-4;;
+            }
           } 
         }  
       }

--- a/app/assets/stylesheets/products_new.scss
+++ b/app/assets/stylesheets/products_new.scss
@@ -59,7 +59,6 @@ $color-4: #ccc;
     margin: 0 auto;
     &__image {
       @extend %box-style;
-      height: 300px;
       &--label {
         @extend %label-style;
       }
@@ -71,19 +70,24 @@ $color-4: #ccc;
         font-size: 14px;
         line-height: 1.4em;
       }
-      &--upload {
-        height: 150px;
+      &__box {
         width: 620px;
-        background-color: $color-0;
-        margin-top: 16px;
-        font-size: 12px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-        border-width: 1px;
-        border-style: dashed;
-        border-color: $color-4;
+        &__data {
+          &__upload {
+            height: 150px;
+            width: 620px;
+            background-color: $color-0;
+            margin-top: 16px;
+            font-size: 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 100%;
+            border-width: 1px;
+            border-style: dashed;
+            border-color: $color-4;
+          } 
+        }  
       }
     }
     &__text {

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -8,11 +8,14 @@
         %label.sell__product__image--label 出品画像
         %span.sell__product__image--span 必須
         %p.sell__product__image--p 最大10枚までアップロードできます
-        = f.fields_for :product_images do |i|
-          = i.label :image, class: 'sell__product__image--upload' do
-            = i.file_field :image, accept:"image/png,image/jpeg", style:"display:none"
-            %img{height: "18", src: "/icon_camera.png", width: "20"}
-            %p ドラッグアンドドロップまたはクリックしてファイル選択
+        .sell__product__image__box
+          = f.fields_for :product_images do |i|
+            .sell__product__image__box__data{data:{index: "#{i.index}"}}
+              = i.label :image, class: 'sell__product__image__box__data__upload' do
+                = i.file_field :image, accept:"image/png,image/jpeg", style:"display:none", class: 'sell__product__image__box__data__upload--js-file'
+                %span.sell__product__image__box__data__upload--js-remove 削除
+                %img{height: "18", src: "/icon_camera.png", width: "20"}
+                %p ドラッグアンドドロップまたはクリックしてファイル選択
       .sell__product__text
         %label.sell__product__text--label 商品名
         %span.sell__product__text--span 必須

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -8,12 +8,13 @@
         %label.sell__product__image--label 出品画像
         %span.sell__product__image--span 必須
         %p.sell__product__image--p 最大10枚までアップロードできます
+        .sell__product__image--preview
         .sell__product__image__box
           = f.fields_for :product_images do |i|
             .sell__product__image__box__data{data:{index: "#{i.index}"}}
               = i.label :image, class: 'sell__product__image__box__data__upload' do
                 = i.file_field :image, accept:"image/png,image/jpeg", style:"display:none", class: 'sell__product__image__box__data__upload--js-file'
-                %span.sell__product__image__box__data__upload--js-remove 削除
+                %span.sell__product__image__box__data__upload--js-remove{data:{index: "0"}} 削除
                 %img{height: "18", src: "/icon_camera.png", width: "20"}
                 %p ドラッグアンドドロップまたはクリックしてファイル選択
       .sell__product__text

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -14,9 +14,9 @@
             .sell__product__image__box__data{data:{index: "#{i.index}"}}
               = i.label :image, class: 'sell__product__image__box__data__upload' do
                 = i.file_field :image, accept:"image/png,image/jpeg", style:"display:none", class: 'sell__product__image__box__data__upload--js-file'
-                %span.sell__product__image__box__data__upload--js-remove{data:{index: "0"}} 削除
                 %img{height: "18", src: "/icon_camera.png", width: "20"}
-                %p ドラッグアンドドロップまたはクリックしてファイル選択
+                %p.sell__product__image__box__data__upload--js-select 選択
+                %span.sell__product__image__box__data__upload--js-remove{data:{index: "0"}, style: "visibility:hidden"}  削除
       .sell__product__text
         %label.sell__product__text--label 商品名
         %span.sell__product__text--span 必須


### PR DESCRIPTION
# what
JavaScriptの記述による複数画像出品出品機能を実装した。
画像投稿UIについては以下を参照。

1-2枚：　https://gyazo.com/afec83b99a2d33ce6c43b97208bffcca
5-6枚：　https://gyazo.com/f42ed64555f5fbb3066938a717338c32
9-10枚：  https://gyazo.com/87a22c131d0bafd1afecc4bfbc67d34f
　　　　（11枚以上は出品できないようJavaScript内で条件分岐を設定）
削除、差し替え：https://gyazo.com/c781f9218cdf48da52500eee37a2db58

why
商品出品機能はS3、商品一覧、カテゴリ等、様々な機能と連動する根幹の機能。
iチームではRails機能、単体テスト、複数画像投稿と分けて実装を行ってきたが、これを最後に出品機能が完成する。